### PR TITLE
mm-video-v4l2: vdec: Add fallback to old MISR_INFO for sdm845 and below.

### DIFF
--- a/mm-core/inc/OMX_QCOMExtns.h
+++ b/mm-core/inc/OMX_QCOMExtns.h
@@ -1231,13 +1231,26 @@ typedef struct OMX_QCOM_CONFIG_INTERLACETYPE
 
 #define MAX_PAN_SCAN_WINDOWS 4
 
+#ifdef VENUS_USES_LEGACY_MISR_INFO
+
 typedef struct OMX_QCOM_MISR_INFO {
-	unsigned int misr_set;
-	unsigned int misr_dpb_luma[8];
-	unsigned int misr_dpb_chroma[8];
-	unsigned int misr_opb_luma[8];
-	unsigned int misr_opb_chroma[8];
+    OMX_U32 misr_dpb_luma;
+    OMX_U32 misr_dpb_chroma;
+    OMX_U32 misr_opb_luma;
+    OMX_U32 misr_opb_chroma;
 } OMX_QCOM_MISR_INFO;
+
+#else
+
+typedef struct OMX_QCOM_MISR_INFO {
+    unsigned int misr_set;
+    unsigned int misr_dpb_luma[8];
+    unsigned int misr_dpb_chroma[8];
+    unsigned int misr_opb_luma[8];
+    unsigned int misr_opb_chroma[8];
+} OMX_QCOM_MISR_INFO;
+
+#endif
 
 typedef struct OMX_QCOM_OUTPUT_CROP {
     OMX_U32 size;

--- a/mm-video-v4l2/vidc/vdec/Android.mk
+++ b/mm-video-v4l2/vidc/vdec/Android.mk
@@ -25,6 +25,7 @@ libmm-vdec-def += -DPROCESS_EXTRADATA_IN_OUTPUT_PORT
 
 TARGETS_THAT_HAVE_VENUS_HEVC := apq8084 msm8994 msm8996
 TARGETS_THAT_DONT_NEED_SW_VDEC := msm8226 msm8916 msm8992 msm8996 sdm660 msm8998 msm8909 sm8150
+TARGETS_THAT_HAVE_LEGACY_VENUS_MISR_INFO := apq8084 msm8909 msm8916 msm8226 msm8952 msm8956 msm8992 msm8994 msm8996 sdm660 msm8998 sdm845
 
 ifeq ($(call is-board-platform-in-list, $(TARGETS_THAT_HAVE_VENUS_HEVC)),true)
 libmm-vdec-def += -DVENUS_HEVC
@@ -50,6 +51,10 @@ endif
 
 ifeq ($(call is-platform-sdk-version-at-least,27),true) # O-MR1
 libmm-vdec-def += -D_ANDROID_O_MR1_DIVX_CHANGES
+endif
+
+ifeq ($(call is-board-platform-in-list, $(TARGETS_THAT_HAVE_LEGACY_VENUS_MISR_INFO)),true)
+libmm-vdec-def += -DVENUS_USES_LEGACY_MISR_INFO
 endif
 
 include $(CLEAR_VARS)

--- a/mm-video-v4l2/vidc/vdec/src/omx_vdec_v4l2.cpp
+++ b/mm-video-v4l2/vidc/vdec/src/omx_vdec_v4l2.cpp
@@ -11358,6 +11358,18 @@ bool omx_vdec::handle_extradata(OMX_BUFFERHEADERTYPE *p_buf_hdr)
                             m_extradata_info.output_width = output_crop_payload->width;
                             m_extradata_info.output_height = output_crop_payload->height;
                             m_extradata_info.output_crop_updated = OMX_TRUE;
+#ifdef VENUS_USES_LEGACY_MISR_INFO
+                            DEBUG_PRINT_HIGH("MISR0: %x %x %x %x\n",
+                                output_crop_payload->misr_info[0].misr_dpb_luma[0],
+                                output_crop_payload->misr_info[0].misr_dpb_chroma[0],
+                                output_crop_payload->misr_info[0].misr_opb_luma[0],
+                                output_crop_payload->misr_info[0].misr_opb_chroma[0]);
+                            DEBUG_PRINT_HIGH("MISR1: %x %x %x %x\n",
+                                output_crop_payload->misr_info[1].misr_dpb_luma[0],
+                                output_crop_payload->misr_info[1].misr_dpb_chroma[0],
+                                output_crop_payload->misr_info[1].misr_opb_luma[0],
+                                output_crop_payload->misr_info[1].misr_opb_chroma[0]);
+#else
                             for(unsigned int m=0; m<output_crop_payload->misr_info[0].misr_set; m++) {
                             DEBUG_PRINT_HIGH("MISR0: %x %x %x %x\n",
                                 output_crop_payload->misr_info[0].misr_dpb_luma[m],
@@ -11372,6 +11384,7 @@ bool omx_vdec::handle_extradata(OMX_BUFFERHEADERTYPE *p_buf_hdr)
                                                  output_crop_payload->misr_info[1].misr_opb_luma[m],
                                                  output_crop_payload->misr_info[1].misr_opb_chroma[m]);
                             }
+#endif
                             memcpy(m_extradata_info.misr_info, output_crop_payload->misr_info, 2 * sizeof(msm_vidc_misr_info));
                             if (client_extradata & OMX_OUTPUTCROP_EXTRADATA) {
                                 if (p_client_extra) {
@@ -11915,6 +11928,29 @@ void omx_vdec::print_debug_extradata(OMX_OTHER_EXTRADATATYPE *extra)
             (unsigned int)outputcrop_info->frame_num,
             (unsigned int)outputcrop_info->bit_depth_y,
             (unsigned int)outputcrop_info->bit_depth_c);
+
+#ifdef VENUS_USES_LEGACY_MISR_INFO
+
+        DEBUG_PRINT_HIGH(
+            "     top field: misr_dpb_luma: %u \n"
+            "   top field: misr_dpb_chroma: %u \n"
+            "     top field: misr_opb_luma: %u \n"
+            "   top field: misr_opb_chroma: %u \n"
+            "  bottom field: misr_dpb_luma: %u \n"
+            "bottom field: misr_dpb_chroma: %u \n"
+            "  bottom field: misr_opb_luma: %u \n"
+            "bottom field: misr_opb_chroma: %u \n",
+            (unsigned int)outputcrop_info->misr_info[0].misr_dpb_luma,
+            (unsigned int)outputcrop_info->misr_info[0].misr_dpb_chroma,
+            (unsigned int)outputcrop_info->misr_info[0].misr_opb_luma,
+            (unsigned int)outputcrop_info->misr_info[0].misr_opb_chroma,
+            (unsigned int)outputcrop_info->misr_info[1].misr_dpb_luma,
+            (unsigned int)outputcrop_info->misr_info[1].misr_dpb_chroma,
+            (unsigned int)outputcrop_info->misr_info[1].misr_opb_luma,
+            (unsigned int)outputcrop_info->misr_info[1].misr_opb_chroma);
+
+#else
+
         for(unsigned int m=0; m<outputcrop_info->misr_info[0].misr_set; m++) {
             DEBUG_PRINT_HIGH(
             "     top field: misr_dpb_luma(%d): %u \n"
@@ -11937,6 +11973,8 @@ void omx_vdec::print_debug_extradata(OMX_OTHER_EXTRADATATYPE *extra)
             m, (unsigned int)outputcrop_info->misr_info[1].misr_opb_luma[m],
             m, (unsigned int)outputcrop_info->misr_info[1].misr_opb_chroma[m]);
         }
+
+#endif
         DEBUG_PRINT_HIGH("================== End of output crop ===========");
     } else if (extra->eType == OMX_ExtraDataNone) {
         DEBUG_PRINT_HIGH("========== End of Terminator ===========");


### PR DESCRIPTION
sm8150 and up have a new misr_info structure, which is not compatible
with older platforms. Add a fallback to be able to reuse this HAL on
legacy platforms.

Tested by @kholk.