### PR TITLE
mm-video-v4l2: vdec: Fix non-subscripted values in misr_info.

### DIFF
--- a/mm-video-v4l2/vidc/vdec/src/omx_vdec_v4l2.cpp
+++ b/mm-video-v4l2/vidc/vdec/src/omx_vdec_v4l2.cpp
@@ -11360,15 +11360,15 @@ bool omx_vdec::handle_extradata(OMX_BUFFERHEADERTYPE *p_buf_hdr)
                             m_extradata_info.output_crop_updated = OMX_TRUE;
 #ifdef VENUS_USES_LEGACY_MISR_INFO
                             DEBUG_PRINT_HIGH("MISR0: %x %x %x %x\n",
-                                output_crop_payload->misr_info[0].misr_dpb_luma[0],
-                                output_crop_payload->misr_info[0].misr_dpb_chroma[0],
-                                output_crop_payload->misr_info[0].misr_opb_luma[0],
-                                output_crop_payload->misr_info[0].misr_opb_chroma[0]);
+                                output_crop_payload->misr_info[0].misr_dpb_luma,
+                                output_crop_payload->misr_info[0].misr_dpb_chroma,
+                                output_crop_payload->misr_info[0].misr_opb_luma,
+                                output_crop_payload->misr_info[0].misr_opb_chroma);
                             DEBUG_PRINT_HIGH("MISR1: %x %x %x %x\n",
-                                output_crop_payload->misr_info[1].misr_dpb_luma[0],
-                                output_crop_payload->misr_info[1].misr_dpb_chroma[0],
-                                output_crop_payload->misr_info[1].misr_opb_luma[0],
-                                output_crop_payload->misr_info[1].misr_opb_chroma[0]);
+                                output_crop_payload->misr_info[1].misr_dpb_luma,
+                                output_crop_payload->misr_info[1].misr_dpb_chroma,
+                                output_crop_payload->misr_info[1].misr_opb_luma,
+                                output_crop_payload->misr_info[1].misr_opb_chroma);
 #else
                             for(unsigned int m=0; m<output_crop_payload->misr_info[0].misr_set; m++) {
                             DEBUG_PRINT_HIGH("MISR0: %x %x %x %x\n",


### PR DESCRIPTION
Reverting the commit that introduced the new misr_info:
0cf4246d3b0781f2fc1dbd0f0f4ca9ec84892021
strangely introduced subscripts on OMX_U32 values, which are not
arrays. This odd constellation has already been a discussion point
because it seemingly compiled fine, especially after validating
VENUS_USES_LEGACY_MISR_INFO has been defined. Except that it strangely
(but correctly) doesn't compile anymore.

I don't know what to say.

Edit: There has been a rogue commit 9ce4b48aae46932874d79207155d449c5baf193f before the struct was updated.
That's what you get when there are _literally three definitions_ of the damn same thing (one in kernel, a `OMX_QCOM_MISR_INFO` and `vdec_misrinfo`).