### PR TITLE
Remove special handling of gralloc headers

### DIFF
--- a/libc2dcolorconvert/Android.mk
+++ b/libc2dcolorconvert/Android.mk
@@ -16,7 +16,7 @@ endif
 LOCAL_HEADER_LIBRARIES := \
         libutils_headers \
         libhardware_headers \
-        display_intf_headers
+        display_headers
 
 LOCAL_SHARED_LIBRARIES := liblog libdl
 

--- a/libc2dcolorconvert/Android.mk
+++ b/libc2dcolorconvert/Android.mk
@@ -16,13 +16,7 @@ endif
 LOCAL_HEADER_LIBRARIES := \
         libutils_headers \
         libhardware_headers \
-        display_headers
-
-ifeq ($(TARGET_USES_GRALLOC1), true)
-LOCAL_HEADER_LIBRARIES += display_intf_headers_gralloc1
-else
-LOCAL_HEADER_LIBRARIES += display_intf_headers_gralloc
-endif
+        display_intf_headers
 
 LOCAL_SHARED_LIBRARIES := liblog libdl
 
@@ -31,5 +25,6 @@ LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE := libc2dcolorconvert
 
 LOCAL_VENDOR_MODULE := true
+
 
 include $(BUILD_SHARED_LIBRARY)

--- a/mm-video-v4l2/vidc/common/Android.mk
+++ b/mm-video-v4l2/vidc/common/Android.mk
@@ -22,7 +22,6 @@ libmm-vidc-def += -D_ANDROID_ICS_
 
 libmm-vidc-inc      := $(LOCAL_PATH)/inc
 libmm-vidc-inc      += $(QCOM_MEDIA_ROOT)/mm-core/inc
-libmm-vidc-inc      += $(TARGET_OUT_HEADERS)/qcom/display
 libmm-vidc-inc      += $(QCOM_MEDIA_ROOT)/libc2dcolorconvert
 ifeq ($(TARGET_COMPILE_WITH_MSM_KERNEL),true)
 libmm-vidc-inc      += $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr/include
@@ -39,7 +38,8 @@ LOCAL_PRELINK_MODULE      := false
 LOCAL_SHARED_LIBRARIES    := liblog libcutils libdl
 
 LOCAL_HEADER_LIBRARIES := \
-        libutils_headers
+        libutils_headers \
+        display_headers
 
 LOCAL_SRC_FILES   += src/vidc_common.cpp
 LOCAL_SRC_FILES   += src/vidc_vendor_extensions.cpp

--- a/mm-video-v4l2/vidc/vdec/Android.mk
+++ b/mm-video-v4l2/vidc/vdec/Android.mk
@@ -115,7 +115,7 @@ LOCAL_HEADER_LIBRARIES := \
         libnativebase_headers \
         libutils_headers \
         libhardware_headers \
-        display_intf_headers
+        display_headers
 
 LOCAL_C_INCLUDES                += $(libmm-vdec-inc)
 LOCAL_ADDITIONAL_DEPENDENCIES   := $(libmm-vdec-add-dep)

--- a/mm-video-v4l2/vidc/vdec/Android.mk
+++ b/mm-video-v4l2/vidc/vdec/Android.mk
@@ -115,13 +115,7 @@ LOCAL_HEADER_LIBRARIES := \
         libnativebase_headers \
         libutils_headers \
         libhardware_headers \
-        display_headers
-
-ifeq ($(TARGET_USES_GRALLOC1), true)
-LOCAL_HEADER_LIBRARIES += display_intf_headers_gralloc1
-else
-LOCAL_HEADER_LIBRARIES += display_intf_headers_gralloc
-endif
+        display_intf_headers
 
 LOCAL_C_INCLUDES                += $(libmm-vdec-inc)
 LOCAL_ADDITIONAL_DEPENDENCIES   := $(libmm-vdec-add-dep)
@@ -163,14 +157,7 @@ LOCAL_HEADER_LIBRARIES := \
         libnativebase_headers \
         libutils_headers \
         libhardware_headers \
-        display_headers
-
-ifeq ($(TARGET_USES_GRALLOC1), true)
-LOCAL_HEADER_LIBRARIES += display_intf_headers_gralloc1
-else
-LOCAL_HEADER_LIBRARIES += display_intf_headers_gralloc
-endif
-
+        display_intf_headers
 
 LOCAL_C_INCLUDES              += $(libmm-vdec-inc)
 LOCAL_ADDITIONAL_DEPENDENCIES := $(libmm-vdec-add-dep)

--- a/mm-video-v4l2/vidc/venc/Android.mk
+++ b/mm-video-v4l2/vidc/venc/Android.mk
@@ -102,13 +102,7 @@ LOCAL_HEADER_LIBRARIES := \
         libcutils_headers \
         libutils_headers \
         libhardware_headers \
-        display_headers
-
-ifeq ($(TARGET_USES_GRALLOC1), true)
-LOCAL_HEADER_LIBRARIES += display_intf_headers_gralloc1
-else
-LOCAL_HEADER_LIBRARIES += display_intf_headers_gralloc
-endif
+        display_intf_headers
 
 LOCAL_C_INCLUDES                := $(libmm-venc-inc)
 LOCAL_ADDITIONAL_DEPENDENCIES   := $(libmm-venc-add-dep)
@@ -151,13 +145,7 @@ LOCAL_HEADER_LIBRARIES := \
         libnativebase_headers \
         libutils_headers \
         libhardware_headers \
-        display_headers
-
-ifeq ($(TARGET_USES_GRALLOC1), true)
-LOCAL_HEADER_LIBRARIES += display_intf_headers_gralloc1
-else
-LOCAL_HEADER_LIBRARIES += display_intf_headers_gralloc
-endif
+        display_intf_headers
 
 LOCAL_C_INCLUDES                := $(libmm-venc-inc)
 LOCAL_ADDITIONAL_DEPENDENCIES   := $(libmm-venc-add-dep)

--- a/mm-video-v4l2/vidc/venc/Android.mk
+++ b/mm-video-v4l2/vidc/venc/Android.mk
@@ -102,7 +102,7 @@ LOCAL_HEADER_LIBRARIES := \
         libcutils_headers \
         libutils_headers \
         libhardware_headers \
-        display_intf_headers
+        display_headers
 
 LOCAL_C_INCLUDES                := $(libmm-venc-inc)
 LOCAL_ADDITIONAL_DEPENDENCIES   := $(libmm-venc-add-dep)


### PR DESCRIPTION
gralloc1 was added in display hal due to an incompatibility between legacy adreno blobs and _something_ in newer gralloc code. The issue is now found to be a struct mismatch that can be handled in the headers.
https://github.com/sonyxperiadev/hardware-qcom-display/pull/26 removes gralloc1 in display hal.

Due to that removal, media hal does not need to consider which set of gralloc headers to use.