### PR TITLE
Partially revert "guard use of kernel sources"

### DIFF
--- a/libarbitrarybytes/Android.mk
+++ b/libarbitrarybytes/Android.mk
@@ -9,11 +9,6 @@ libarbitrarybytes-inc  := $(LOCAL_PATH)/inc
 libarbitrarybytes-inc  += $(LOCAL_PATH)/../mm-video-v4l2/vidc/common/inc/
 libarbitrarybytes-inc  += $(LOCAL_PATH)/../mm-core/inc
 
-ifeq ($(TARGET_COMPILE_WITH_MSM_KERNEL),true)
-LOCAL_ADDITIONAL_DEPENDENCIES += $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr
-libarbitrarybytes-inc  := $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr/include
-endif
-
 LOCAL_MODULE           := libarbitrarybytes
 
 LOCAL_PRELINK_MODULE   := false

--- a/libc2dcolorconvert/Android.mk
+++ b/libc2dcolorconvert/Android.mk
@@ -8,11 +8,6 @@ LOCAL_SRC_FILES := \
 LOCAL_C_INCLUDES := \
     $(TARGET_OUT_HEADERS)/adreno
 
-
-ifeq ($(TARGET_COMPILE_WITH_MSM_KERNEL),true)
-LOCAL_C_INCLUDES += $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr/include
-endif
-
 LOCAL_HEADER_LIBRARIES := \
         libutils_headers \
         libhardware_headers \

--- a/mm-video-v4l2/vidc/common/Android.mk
+++ b/mm-video-v4l2/vidc/common/Android.mk
@@ -23,9 +23,6 @@ libmm-vidc-def += -D_ANDROID_ICS_
 libmm-vidc-inc      := $(LOCAL_PATH)/inc
 libmm-vidc-inc      += $(QCOM_MEDIA_ROOT)/mm-core/inc
 libmm-vidc-inc      += $(QCOM_MEDIA_ROOT)/libc2dcolorconvert
-ifeq ($(TARGET_COMPILE_WITH_MSM_KERNEL),true)
-libmm-vidc-inc      += $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr/include
-endif
 libmm-vidc-inc      += $(TOP)/hardware/libhardware/include
 
 LOCAL_MODULE                    := libOmxVidcCommon

--- a/mm-video-v4l2/vidc/vdec/Android.mk
+++ b/mm-video-v4l2/vidc/vdec/Android.mk
@@ -78,11 +78,6 @@ libmm-vdec-inc += $(QCOM_MEDIA_ROOT)/libstagefrighthw
 endif
 
 # Common Dependencies
-ifeq ($(TARGET_COMPILE_WITH_MSM_KERNEL),true)
-libmm-vdec-inc      	+= $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr/include
-libmm-vdec-add-dep := $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr
-endif
-
 ifeq ($(call is-platform-sdk-version-at-least, 19),true)
 # This feature is enabled for Android KK+
 libmm-vdec-def += -DADAPTIVE_PLAYBACK_SUPPORTED

--- a/mm-video-v4l2/vidc/venc/Android.mk
+++ b/mm-video-v4l2/vidc/venc/Android.mk
@@ -84,12 +84,6 @@ ifneq ($(call is-board-platform-in-list, $(TARGETS_THAT_DONT_SUPPORT_SW_VENC_ROT
 libmm-venc-inc      += hardware/libhardware/include/hardware
 endif
 
-# Common Dependencies
-ifeq ($(TARGET_COMPILE_WITH_MSM_KERNEL),true)
-libmm-venc-inc      += $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr/include
-libmm-venc-add-dep  := $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr
-endif
-
 # ---------------------------------------------------------------------------------
 # 			Make the Shared library (libOmxVenc)
 # ---------------------------------------------------------------------------------


### PR DESCRIPTION
This fixes a build error about missing headers in the custom ROMs Pixel Experience and LineageOS

These ROMs using inline kernel building, but the needed header files won't be in $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr/include

Anyway Google deprecated kernel inline building in Android 10, which makes the kernel guard using the TARGET_COMPILE_WITH_MSM_KERNEL flag obsolete

This partially reverts commit cc60e217fd948ea4bb7aa8df627ff0fb3bc6afd5.

@Paulbouchara confirmed the fix.

I am happy about any critics, if this approach goes in the wrong direction.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sonyxperiadev/hardware-qcom-media/5)
<!-- Reviewable:end -->
