### PR TITLE
[LA.UM.8.1.r1] libarbitrarybytes : Fixing inline compilation

### DIFF
--- a/libarbitrarybytes/Android.mk
+++ b/libarbitrarybytes/Android.mk
@@ -11,7 +11,7 @@ libarbitrarybytes-inc  += $(LOCAL_PATH)/../mm-core/inc
 
 ifeq ($(TARGET_COMPILE_WITH_MSM_KERNEL),true)
 LOCAL_ADDITIONAL_DEPENDENCIES += $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr
-libarbitrarybytes-inc  := $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr/include
+libarbitrarybytes-inc  += $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr/include
 endif
 
 LOCAL_MODULE           := libarbitrarybytes


### PR DESCRIPTION
Replace the faulty := at line 14 which broke inline compilation to += 

Now, all the headers from the HAL are included plus the one generated from the kernel.