### PR TITLE
[LA.UM.8.1.r1] Android.mk: add build guard

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,3 +1,5 @@
+ifneq ($(filter $(QCOM_NEW_MEDIA_PLATFORM), $(TARGET_BOARD_PLATFORM)),)
+
 QCOM_MEDIA_ROOT := $(call my-dir)
 
 #Compile these for all targets under QCOM_BOARD_PLATFORMS list.
@@ -13,5 +15,6 @@ include $(QCOM_MEDIA_ROOT)/libc2dcolorconvert/Android.mk
 include $(QCOM_MEDIA_ROOT)/libarbitrarybytes/Android.mk
 ifeq ($(ENABLE_HYP),true)
 include $(QCOM_MEDIA_ROOT)/hypv-intercept/Android.mk
+endif
 endif
 endif


### PR DESCRIPTION
Only include the hal in the build if the target platform is in QCOM_NEW_MEDIA_PLATFORM