### PR TITLE
[LA.UM.8.2.1.r1] Android.mk: add build guard

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,3 +1,5 @@
+ifeq ($(filter $(QCOM_NEW_MEDIA_PLATFORM), $(TARGET_BOARD_PLATFORM)),)
+
 QCOM_MEDIA_ROOT := $(call my-dir)
 
 #Compile these for all targets under QCOM_BOARD_PLATFORMS list.
@@ -20,4 +22,5 @@ ifeq ($(TARGET_BOARD_AUTO),true)
 include $(QCOM_MEDIA_ROOT)/libsidebandstreamhandle/Android.mk
 endif
 
+endif
 endif


### PR DESCRIPTION
Only include the hal in the build if the target platform is NOT in QCOM_NEW_MEDIA_PLATFORM