### PR TITLE
[8.1.r1] mm-core: Error for forgotten new platforms

### DIFF
--- a/mm-core/Android.mk
+++ b/mm-core/Android.mk
@@ -98,6 +98,7 @@ LOCAL_SRC_FILES         += src/$(MM_CORE_TARGET)/registry_table_android.c
 else ifneq (,$(filter sm8150 sdmshrike $(MSMSTEPPE) $(TRINKET) atoll,$(TARGET_BOARD_PLATFORM)))
 LOCAL_SRC_FILES         += src/registry_table_android.c
 else
+$(error "sm8150 media HAL: The device/platform that was building is not included in the TARGET_BOARD_PLATFORM whitelist")
 LOCAL_SRC_FILES         += src/qc_registry_table_android.c
 endif
 


### PR DESCRIPTION
src/qc_registry_table_android.c does not exist, yet
src/default/registry_table_android.c does.

But we never want to reach this point anyway as it will
hide further issues. Error out instead to get the platform
list fixed instead.