### PR TITLE
[8.2.r1] mm-core: Error for forgotten new platforms

### DIFF
--- a/mm-core/Android.mk
+++ b/mm-core/Android.mk
@@ -121,6 +121,7 @@ LOCAL_SRC_FILES         += src/common/qc_omx_core.c
 ifneq (,$(filter msm8916 msm8994 msm8909 msm8937 msm8996 msm8992 msm8952 msm8953 msm8998 apq8098_latv sdm660,$(TARGET_BOARD_PLATFORM)))
 LOCAL_SRC_FILES         += src/$(MM_CORE_TARGET)/registry_table_android.c
 else
+$(error "sdm660-libion media HAL: The device/platform that was building is not included in the TARGET_BOARD_PLATFORM whitelist")
 LOCAL_SRC_FILES         += src/$(MM_CORE_TARGET)/qc_registry_table_android.c
 endif
 


### PR DESCRIPTION
src/$(MM_CORE_TARGET)/qc_registry_table_android.c does not exist, yet
src/$(MM_CORE_TARGET)/registry_table_android.c does.

But we never want to reach this point anyway as it will
hide further issues. Error out instead to get the platform
list fixed instead.