### PR TITLE
[8.1.r1] mm-core: Do not include qc_registry_table.c

### DIFF
--- a/mm-core/Android.mk
+++ b/mm-core/Android.mk
@@ -98,6 +98,7 @@ LOCAL_SRC_FILES         += src/$(MM_CORE_TARGET)/registry_table_android.c
 else ifneq (,$(filter sm8150 sdmshrike $(MSMSTEPPE) $(TRINKET) atoll,$(TARGET_BOARD_PLATFORM)))
 LOCAL_SRC_FILES         += src/registry_table_android.c
 else
+$(error "sm8150 media HAL: Refusing to include example file qc_registry_table.c, check if TARGET_BOARD_PLATFORM is correct and in the filter above")
 LOCAL_SRC_FILES         += src/qc_registry_table_android.c
 endif
 


### PR DESCRIPTION
qc_registry_table.c is an example file that contains no usable configuration whatsoever,
and will likely result in a wild goose chase why our encoders/decoders
are not working.
Prevent our future selves from suffering by not including this file.