### PR TITLE
[MEDIA] libc2dcolorconvert: Re-export display_headers for c2d2.h

### DIFF
--- a/libc2dcolorconvert/Android.mk
+++ b/libc2dcolorconvert/Android.mk
@@ -18,6 +18,9 @@ LOCAL_HEADER_LIBRARIES := \
         libhardware_headers \
         display_headers
 
+LOCAL_EXPORT_HEADER_LIBRARY_HEADERS := \
+    display_headers
+
 LOCAL_SHARED_LIBRARIES := liblog libdl
 
 LOCAL_MODULE_TAGS := optional


### PR DESCRIPTION
In the near future we will finally be moving away from header copies and
instead expose header include directories and propagate these. This
unfortunately requires dependencies to be on point which they obviously
aren't yet: libc2dcolorconvert uses c2d2.h from display_headers in its
own public headers but does not re-export them, meaning that any
consumer of these headers will fail to compile.

In this concrete case vdec import display_headers yet venc doesn't,
resulting in the aforementioned compiler error. (Again, assuming a
display hal without legacy COPY_HEADERS is used).
