### PR TITLE
[aosp/LA.UM.8.2.1.r1] Disable TARGET_BOARD_AUTO

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -18,9 +18,5 @@ endif
 
 include $(QCOM_MEDIA_ROOT)/hypv-intercept/Android.mk
 
-ifeq ($(TARGET_BOARD_AUTO),true)
-include $(QCOM_MEDIA_ROOT)/libsidebandstreamhandle/Android.mk
-endif
-
 endif
 endif


### PR DESCRIPTION
There is no need nowadays to rely on AUTO platform features.

This should be tested on !QCOM_NEW_MEDIA_PLATFORM devices (nile and yoshino). It has been tested locally on nile (pioneer).